### PR TITLE
Timestamp for the file watchdog message

### DIFF
--- a/frog/frog.rkt
+++ b/frog/frog.rkt
@@ -1123,7 +1123,9 @@ EOF
                                   (append (map post-uri-path posts) pages)))])
              (displayln x))))
   (stop-pygments)
-  (prn0 "Done generating files")
+  (let* ([d (current-date)]
+         [n (lambda (x) (~r (x d) #:min-width 2 #:pad-string "0"))])
+    (prn0 (~a (n date-hour) ":" (n date-minute) " Done generating files")))
   (void))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Sometimes, when running frog with -w, i'm not sure whether a change
will trigger a rebuild or not, and at other times i just want to have
a quick visual cue of when i last rebuilt the blog.
