### PR TITLE
added missing </div> tag in page-template

### DIFF
--- a/example/_src/page-template.html
+++ b/example/_src/page-template.html
@@ -67,6 +67,7 @@
             <li><a href="@|rss-feed-uri|">RSS</a></li>
           </ul>
         </div>
+      </div>
     </header>
     <div class="container">
       <div class="row">


### PR DESCRIPTION
Hi,

the close tag for the container div in exampe/_src/page-template.html is missing. When you view the generated html in Firefox you can see it.

Great site generator, I use it for my blog :)
