### PR TITLE
Problem with Pygments and Python 3

### DIFF
--- a/frog/pipe.py
+++ b/frog/pipe.py
@@ -25,6 +25,7 @@ from pygments.formatters import HtmlFormatter
 formatter = HtmlFormatter(linenos=True, cssclass="source", encoding="utf-8")
 lexer = ""
 code = ""
+py_version = sys.version_info.major
 sys.stdout.write("ready\n")
 sys.stdout.flush
 while 1:
@@ -36,8 +37,11 @@ while 1:
     if line == '__EXIT__':
         break
     elif line == '__END__':
-        # Lex input finished. Lex it.
-        sys.stdout.write(highlight(code, lexer, formatter))
+        # Lex input finished. Lex it.        
+        if py_version >= 3:
+          sys.stdout.write(highlight(code, lexer, formatter).decode("utf-8"))
+        else:
+          sys.stdout.write(highlight(code, lexer, formatter))
         sys.stdout.write('\n__END__\n')
         sys.stdout.flush
         lexer = ""


### PR DESCRIPTION
Hi,

i found that pipe.py throws a TypeError when using Python 3. The reason is in line 40:

```
sys.stdout.write(highlight(code, lexer, formatter))
```

_sys.stdout.write_ seems to only accept instances of 'str'. Python 3 returns 'bytes' from the highlight call here. My idea was to check the python version and then act accordingly. I've tested this with Python 2.7.6 and Python 3.3.4 and both worked. But i don't really know a lot about Python so there might be a better solution.

Regards,
Peter
