### PR TITLE
Added support for editing new posts with --edit

### DIFF
--- a/example/.frogrc
+++ b/example/.frogrc
@@ -4,6 +4,16 @@ scheme/host = http://www.example.com
 title = My Awesome Blog
 author = The Unknown Author
 
+# What editor to launch with --edit. $EDITOR means to use $EDITOR from
+# the environment
+editor = $EDITOR
+
+# The command to run, in case you need to customize how the editor is
+# called. For example, {editor} {filename} will call:
+# (system "$EDITOR 2012-01-01-a-blog-post.md")
+# See the test submodule in paths.rkt for more examples
+editor-command = {editor} {filename}
+
 # Whether to show the count of posts next to each tag in sidebar
 show-tag-counts? = true
 

--- a/frog/frog.rkt
+++ b/frog/frog.rkt
@@ -566,6 +566,8 @@ published.
 EOF
 )
 
+(define enable-editor (make-parameter #f))
+
 (define (new-post title [type 'markdown])
   (let ([extension (case type
                      [(markdown) ".md"]
@@ -589,10 +591,12 @@ EOF
                         pathname
                         #:exists 'error)
       (displayln pathname)
-      ;; (define editor (getenv "EDITOR"))
-      ;; (when editor
-      ;;   (system (format "~a ~a &" editor (path->string pathname))))
-      )))
+      (when (enable-editor)
+        (system (editor-command-string 
+                  (regexp-replaces (current-editor)
+                                   `([#rx"\\$EDITOR" ,(getenv "EDITOR")]))
+                  (path->string pathname) 
+                  (current-editor-command)))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
@@ -832,6 +836,8 @@ EOF
                               ([scheme/host "http://www.example.com"]
                                [title "Untitled Site"]
                                [author "The Unknown Author"]
+                               [editor "$EDITOR"]
+                               [editor-command "{editor} {filename}"]
                                [show-tag-counts? #t]
                                [permalink "/{year}/{month}/{title}.html"]
                                [index-full? #f]
@@ -878,6 +884,8 @@ EOF
                               ([scheme/host "http://www.example.com"]
                                [title "Untitled Site"]
                                [author "The Unknown Author"]
+                               [editor "$EDITOR"]
+                               [editor-command "{editor} {filename}"]
                                [show-tag-counts? #t]
                                [permalink "/{year}/{month}/{title}.html"]
                                [index-full? #f]
@@ -903,6 +911,11 @@ EOF
          "Initialize current directory as a new Frog project, creating"
          "default files as a starting point.")
         (init-project)]
+       [("--edit") 
+        (""
+         "Opens the file created by -n or -N in editor as specified in .frogrc"
+         "Supply this flag before one of those flags.")
+        (enable-editor #t)]
        #:multi
        [("-n" "--new") title
         (""

--- a/frog/params.rkt
+++ b/frog/params.rkt
@@ -7,6 +7,8 @@
 (define current-scheme/host (make-parameter #f))
 (define current-title (make-parameter #f))
 (define current-author (make-parameter #f))
+(define current-editor (make-parameter #f))
+(define current-editor-command (make-parameter #f))
 (define current-permalink (make-parameter #f))
 (define current-index-full? (make-parameter #f)) ;index pages: full posts?
 (define current-feed-full? (make-parameter #f))  ;feeds: full posts?

--- a/frog/paths.rkt
+++ b/frog/paths.rkt
@@ -159,3 +159,25 @@
     (check-equal?
      (post-path->link (build-path (top) "blog/2012/05/31/title-of-post/index.html"))
      "/blog/2012/05/31/title-of-post/")))
+
+;; I'm not really sure where to put this so ...
+(define/contract (editor-command-string editor filename pattern)
+  (string? string? string? . -> . string?)
+  (regexp-replaces pattern
+                   `([#rx"{editor}" ,editor]
+                     [#rx"{filename}",filename])))
+
+(module+ test
+  (parameterize ([top (find-system-path 'home-dir)])
+    (define f (curry editor-command-string
+                     "vim" "2012-05-31-title-of-post.md"))
+    (check-equal? (f "{editor} {filename}")
+                  "vim 2012-05-31-title-of-post.md")
+    (check-equal? (f "emacsclient /tmp/draft.md")
+                  "emacsclient /tmp/draft.md")
+    (check-equal? (f "exec {editor} {filename} >/dev/null 2>&1 &")
+                  "exec vim 2012-05-31-title-of-post.md >/dev/null 2>&1 &")
+    (check-equal? (f "exo-open --launch TerminalEmulator '{editor} {filename}'")
+                  "exo-open --launch TerminalEmulator 'vim 2012-05-31-title-of-post.md'")))
+
+


### PR DESCRIPTION
I notice there was once support for automagically launching an editor on new posts. This seems to be a super obvious feature, and others (e.g., https://github.com/cjfrisz/frog-plus) add it via shell scripts on top of Frog, so I'm guessing it was removed because it's hard to make it work with all the unique combinations of editors and environments out there ...

But I didn't want to resort to a bash script parsing the output of Frog, so I hacked up something I think should work for most people.

I welcome comments and criticisms. 
