### PR TITLE
Configurable pygments linenos and cssclass (fixes #93)

### DIFF
--- a/example/.frogrc
+++ b/example/.frogrc
@@ -93,3 +93,9 @@ source-dir = _src
 # to the project top directory, i.e. to where this .frogrc file is
 # located.
 output-dir = .
+
+# Options controlling Pygments' HTML format.
+## Whether to use line numbers.
+pygments-linenos? = true
+## CSS class for the wrapping <div> tag (default: 'highlight').
+pygments-cssclass = source

--- a/frog/frog.rkt
+++ b/frog/frog.rkt
@@ -49,7 +49,9 @@
                                [index-newest-first? #t]
                                [posts-index-uri "/index.html"]
                                [source-dir "_src"]
-                               [output-dir "."])
+                               [output-dir "."]
+                               [pygments-linenos? #t]
+                               [pygments-cssclass "source"])
       (define watch? #f)
       (define port 3000)
       (command-line
@@ -226,7 +228,7 @@
                        (hash-ref new-posts (post-newer post) #f))))
 
   ;; [2] Tags: Output to index pages and feed files
-  ;; 
+  ;;
   ;; (a) Delete obsolete output files, for tags no longer in use.
   (for ([tag (in-list (hash-keys old-tags))])
     (unless (hash-has-key? new-tags tag)
@@ -267,7 +269,7 @@
 
   ;; [4] Non-post pages.
   (define non-post-pages (build-non-post-pages))
-  
+
   ;; [5] sitemap.txt, populated from new-posts and non-post-pages.
   ;;     (Generating this is cheap, so just always do it.)
   (prn1 "Generating sitemap.txt")

--- a/frog/params.rkt
+++ b/frog/params.rkt
@@ -24,3 +24,5 @@
 (define current-posts-index-uri (make-parameter "/index.html"))
 (define current-source-dir (make-parameter "_src"))
 (define current-output-dir (make-parameter "."))
+(define current-pygments-linenos? (make-parameter #t))
+(define current-pygments-cssclass (make-parameter "source"))

--- a/frog/pipe.py
+++ b/frog/pipe.py
@@ -17,12 +17,21 @@
 #     __END__
 
 import sys
+import optparse
 from pygments import highlight
 from pygments.lexers import get_lexer_by_name
 from pygments.util import ClassNotFound
 from pygments.formatters import HtmlFormatter
 
-formatter = HtmlFormatter(linenos=True, cssclass="source", encoding="utf-8")
+parser = optparse.OptionParser()
+parser.add_option('--linenos', action="store_true", dest="linenos")
+parser.add_option('--cssclass', default="source", dest="cssclass")
+(options, _) = parser.parse_args()
+
+formatter = HtmlFormatter(linenos=options.linenos,
+                          cssclass=options.cssclass,
+                          encoding="utf-8")
+
 lexer = ""
 code = ""
 py_version = sys.version_info.major
@@ -37,7 +46,7 @@ while 1:
     if line == '__EXIT__':
         break
     elif line == '__END__':
-        # Lex input finished. Lex it.        
+        # Lex input finished. Lex it.
         if py_version >= 3:
           sys.stdout.write(highlight(code, lexer, formatter).decode("utf-8"))
         else:


### PR DESCRIPTION
We introduce the .frogrc parameters `pygments-linenos?` and
`pygments-cssclass`, which are passed to `HtmlFormatter`.  Other parameters
accepted by the latter, like anchoring prefixes, would be more useful if
the formatter's context were a whole post rather than individual
snippets, so i've opted for not adding further support for them.
