### PR TITLE
update to google analytics supplied by Google circa 2014-12.

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,7 +564,7 @@ templates. Plus they make clearer what are the user-specific
 parameters (as opposed to putting stuff like `<!-- CHANGE THIS! -->`
 in the template).
 
-For example, `@google-analytics["UA-xxxxx" "example.com"]` returns
+For example, `@google-universal-analytics["UA-xxxxx"]` returns
 text for a `<script>` element to insert Google Analytics tracking
 code. You supply it the two user-specific pieces of information, which
 it plugs into the boilerplate and returns.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -137,17 +137,13 @@ In `page-template.html`, set it:
     <link rel="icon" href="/favicon.ico">
 ```
 
-## `google-analytics-account` and `google-analytics-domain`
+## `google-analytics-account`
 
-In `page-template.html`, set these:
+In `page-template.html`, set this:
 
 ```html
-    <script type="text/javascript">
-      var _gaq = _gaq || [];
-      _gaq.push(['_setAccount', 'UA-xxxxxx']);       <!-- SET THIS -->
-      _gaq.push(['_setDomainName', 'example.com']);  <!-- SET THIS -->
-      _gaq.push(['_trackPageview']);
-      ....
+    @google-universal-analytics["UA-xxxxxxxx"] <!-- SET THIS -->
+    ...
 ```
 
 ## `disqus-shortname`

--- a/example/_src/page-template.html
+++ b/example/_src/page-template.html
@@ -25,7 +25,7 @@
     <link ref="alternate" type="application/rss+xml"
           href="@|rss-feed-uri|" title="RSS Feed">
     <!-- JS -->
-    @google-analytics["UA-xxxxx" "example.com"]
+    @google-universal-analytics["UA-xxxxx"]
   </head>
   <body>
     <!-- A standard Twitter Bootstrap nav bar -->

--- a/frog/widgets.rkt
+++ b/frog/widgets.rkt
@@ -97,6 +97,21 @@
 ;; Google Analytics
 ;;
 
+;; for users of "universal" analytics (analytics.js)
+(define (google-universal-analytics account)
+   @list{
+         <script type="text/javascript">
+           (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+           (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+           m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+           })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+           ga('create', '@|account|', 'auto');
+           ga('send', 'pageview');
+         </script>
+         })
+
+;; for users of "classic" analytics (ga.js)
 (define (google-analytics account domain)
    @list{
          <script type="text/javascript">
@@ -114,6 +129,8 @@
            })();
          </script>
          })
+
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;


### PR DESCRIPTION
it appears that you must upgrade to 'universal' analytics on
the google side, but that this is the default for new accounts.

accordingly, I've left the existing google-analytics call intact,
but added a new google-universal-analytics call, and changed the
README's and templates to refer to the new one.
