### PR TITLE
Add config param for python executable

### DIFF
--- a/example/.frogrc
+++ b/example/.frogrc
@@ -100,6 +100,10 @@ source-dir = _src
 output-dir = .
 
 # Options controlling Pygments' HTML format.
+## Python executable to be passed to the shell. If only a filename or
+## relative path is given, Racket's find-executable-path will be used
+## to locate the executable.
+python-executable = python
 ## Whether to use line numbers.
 pygments-linenos? = true
 ## CSS class for the wrapping <div> tag (default: 'highlight').

--- a/frog/frog.rkt
+++ b/frog/frog.rkt
@@ -55,6 +55,7 @@
                                [posts-index-uri "/index.html"]
                                [source-dir "_src"]
                                [output-dir "."]
+                               [python-executable "python"]
                                [pygments-linenos? #t]
                                [pygments-cssclass "source"])
       (define watch? #f)

--- a/frog/params.rkt
+++ b/frog/params.rkt
@@ -24,5 +24,6 @@
 (define current-posts-index-uri (make-parameter "/index.html"))
 (define current-source-dir (make-parameter "_src"))
 (define current-output-dir (make-parameter "."))
+(define current-python-executable (make-parameter "python"))
 (define current-pygments-linenos? (make-parameter #t))
 (define current-pygments-cssclass (make-parameter "source"))


### PR DESCRIPTION
 * Add default & explanation to the .frogrc
 * Add python-executable param to frog.rkt and params.rkt
 * Add explicit location of executable and an existence check/warning to pygments.rkt

I made these changes because I'd installed Pygments under python3 on my machine, but the default in my path was Python 2 and Frog consequently couldn't find Pygments.