### PR TITLE
Support rerooting frog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,12 @@ example/tags/
 example/2*
 example/A-Non-Post-Scribble-Page*
 example/img/posts/
+
+# Emacs / DrRacket backups & auto save files
+*~
+\#*\#
+.\#*
+
+# Emacs tags
+TAGS
+

--- a/example/.frogrc
+++ b/example/.frogrc
@@ -1,10 +1,10 @@
 # Required: Should NOT end in trailing slash.
 scheme/host = http://www.example.com
 
-# Prefix for URIs, default being /
-# this will be interposed at the beginning of any URI, including those
-# specified here.
-#uri-prefix = /
+# A path prepended to URIs, including those specified here in .frogrc
+# such as `permalink` and `posts-index-uri`. Defaults to `/`. This is
+# useful when you want to embed your blog in another web site.
+uri-prefix = /
 
 # The title of the blog. Used when generating feeds.
 title = My Awesome Blog

--- a/example/.frogrc
+++ b/example/.frogrc
@@ -1,6 +1,11 @@
 # Required: Should NOT end in trailing slash.
 scheme/host = http://www.example.com
 
+# Prefix for URIs, default being /
+# this will be interposed at the beginning of any URI, including those
+# specified here.
+#uri-prefix = /
+
 # The title of the blog. Used when generating feeds.
 title = My Awesome Blog
 

--- a/frog/bodies-page.rkt
+++ b/frog/bodies-page.rkt
@@ -71,11 +71,11 @@
                     ,@(if (current-show-tag-counts?) `(,(format "(~a)" v)) '())
                     " "
                     (a ([href ,(atom-feed-uri k)])
-                       (img ([src "/img/feed.png"]))))))
+                       (img ([src ,(canonicalize-uri "/img/feed.png")]))))))
     (p (a ([href ,(current-posts-index-uri)]) "All Posts")
        " "
        (a ([href ,(atom-feed-uri "all")])
-          (img ([src "/img/feed.png"])))))))
+          (img ([src ,(canonicalize-uri "/img/feed.png")])))))))
 
 (define (tags-list-items)
   (for/list ([(k v) (in-dict (tags-alist))])
@@ -95,7 +95,7 @@
                         ", ")))
 
 (define (tag->xexpr s)
-  `(a ([href ,(str "/tags/" (our-encode s) ".html")]) ,s))
+  `(a ([href ,(canonicalize-uri (str "/tags/" (our-encode s) ".html"))]) ,s))
 
 (define (blurb->description s)
   (~> (with-input-from-string s read-html-as-xexprs)

--- a/frog/feeds.rkt
+++ b/frog/feeds.rkt
@@ -27,7 +27,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (atom-feed-uri tag)
-  (str "/feeds/" tag ".atom.xml"))
+  (canonicalize-uri (str "/feeds/" tag ".atom.xml")))
 
 (define (write-atom-feed xs title tag of-uri-path file)
   (prn1 "Generating ~a" (abs->rel/www file))
@@ -41,7 +41,7 @@
       [xml:lang "en"])
      (title ([type "text"]) ,(str (current-title) ": " title))
      (link ([rel "self"]
-            [href ,(full-uri (abs->rel/www file))]))
+            [href ,(full-uri (canonicalize-uri (abs->rel/www file)))]))
      (link ([href ,(full-uri of-uri-path)]))
      (id () ,(str "urn:"
                  (our-encode (current-scheme/host))
@@ -86,7 +86,7 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (define (rss-feed-uri tag)
-  (str "/feeds/" tag ".rss.xml"))
+  (canonicalize-uri (str "/feeds/" tag ".rss.xml")))
 
 (define (write-rss-feed xs title tag of-uri-path file)
   (prn1 "Generating ~a" (abs->rel/www file))
@@ -115,7 +115,8 @@
 
 (define (post->rss-feed-entry-xexpr tag x)
   (match-define (post title src-path modtime dest-path uri-path date older newer tags blurb more? body) x)
-  (define item-uri (full-uri/decorated uri-path #:source tag #:medium "RSS"))
+  (define item-uri (full-uri/decorated uri-path
+                                       #:source tag #:medium "RSS"))
   `(item
     ()
     (title ,title)

--- a/frog/frog.rkt
+++ b/frog/frog.rkt
@@ -36,6 +36,7 @@
   (parameterize* ([top (find-frog-root)])
     (parameterize-from-config (build-path (top) ".frogrc")
                               ([scheme/host "http://www.example.com"]
+                               [uri-prefix #f]
                                [title "Untitled Site"]
                                [author "The Unknown Author"]
                                [editor "$EDITOR"]

--- a/frog/frog.rkt
+++ b/frog/frog.rkt
@@ -108,8 +108,9 @@
         (set! port (string->number number))]
        [("--root") path
         (""
-         "the root directory for -s/--serve or -p/--preview."
-         "Supply this flags before one of those flags."
+         "The root directory for -s/--serve or -p/--preview."
+         "Supply this flag before one of those flags."
+         "If .frogrc has uri-prefix = /path/to/site/blog, try --root /path/to/site"
          "Default: output-dir as specified in .frogrc, or \".\"")
         (set! root path)]
        #:once-any

--- a/frog/frog.rkt
+++ b/frog/frog.rkt
@@ -59,6 +59,7 @@
                                [pygments-cssclass "source"])
       (define watch? #f)
       (define port 3000)
+      (define root (www-path))
       (command-line
        #:program "frog"
        #:once-each
@@ -103,19 +104,27 @@
          "Supply this flag before one of those flags."
          "Default: 3000.")
         (set! port (string->number number))]
+       [("--root") path
+        (""
+         "the root directory for -s/--serve or -p/--preview."
+         "Supply this flags before one of those flags."
+         "Default: output-dir as specified in .frogrc, or \".\"")
+        (set! root path)]
        #:once-any
        [("-s" "--serve")
         (""
          "Run a local web server.")
         (serve #:launch-browser? #f
                #:watch? watch?
-               #:port port)]
+               #:port port
+               #:root root)]
        [("-p" "--preview")
         (""
          "Run a local web server and start your browser on blog home page.")
         (serve #:launch-browser? #t
                #:watch? watch?
-               #:port port)]
+               #:port port
+               #:root root)]
        #:once-any
        [("-S" "--silent") "Silent. Put first."
         (current-verbosity -1)]
@@ -324,7 +333,8 @@
 
 (define (serve #:launch-browser? launch-browser?
                #:watch? watch?
-               #:port port)
+               #:port port
+               #:root root)
   (define watcher-thread
     (cond [watch? (watch-directory (build-path (src-path))
                      '(file)
@@ -341,7 +351,7 @@
     (ensure-external-browser-preference))
   (serve/servlet (lambda (_) (next-dispatcher))
                  #:servlet-path "/"
-                 #:extra-files-paths (list (www-path))
+                 #:extra-files-paths (list root)
                  #:port port
                  #:listen-ip #f
                  #:launch-browser? launch-browser?)

--- a/frog/non-posts.rkt
+++ b/frog/non-posts.rkt
@@ -52,7 +52,7 @@
                                   (~> path
                                       (path-replace-suffix ".html")
                                       abs->rel/src)))
-    (define uri-path (abs->rel/www dest-path))
+    (define uri-path (canonicalize-uri (abs->rel/www dest-path)))
     (unless (stale? dest-path path (page-template.html))
       (prn2 "Already up-to-date: ~a" dest-path)
       (return (cons uri-path v)))
@@ -63,7 +63,8 @@
              (define img-dest (path-replace-suffix dest-path ""))
              (read-scribble-file path
                                  #:img-local-path img-dest
-                                 #:img-uri-prefix (abs->rel/www img-dest))]
+                                 #:img-uri-prefix (canonicalize-uri
+                                                   (abs->rel/www img-dest)))]
             [_ (parse-markdown path)])
           enhance-body))
     (prn1 "Generating non-post ~a" (abs->rel/www dest-path))

--- a/frog/params.rkt
+++ b/frog/params.rkt
@@ -1,11 +1,19 @@
 #lang racket/base
 
+(require racket/match)
+
 (provide (all-defined-out))
 
 ;; Parameters loaded from configuration file
 
 (define current-scheme/host (make-parameter #f))
-(define current-uri-prefix (make-parameter #f))
+(define current-uri-prefix
+  (make-parameter #f
+                  (λ (v)
+                    (and v
+                         (match (regexp-replace #px"/+$" v "")
+                           ["" #f]
+                           [v v])))))
 (define current-title (make-parameter #f))
 (define current-author (make-parameter #f))
 (define current-editor (make-parameter #f))

--- a/frog/params.rkt
+++ b/frog/params.rkt
@@ -5,6 +5,7 @@
 ;; Parameters loaded from configuration file
 
 (define current-scheme/host (make-parameter #f))
+(define current-uri-prefix (make-parameter #f))
 (define current-title (make-parameter #f))
 (define current-author (make-parameter #f))
 (define current-editor (make-parameter #f))

--- a/frog/paths.rkt
+++ b/frog/paths.rkt
@@ -195,16 +195,11 @@
 ;; Possibly rewrite a URI path to take account of the current root
 ;; If full is given make it a full URI, or explode if it makes no sense
 ;; This probably should handle URIs with protocol & host, but does not.
-;;
 (define/contract (canonicalize-uri uri-path)
   (string? . -> . string?)
-  (match uri-path
-    [(pregexp #px"^/")
-     (let ([c (current-uri-prefix)])
-       (if c
-           (str (regexp-replace #px"/+$" c "") uri-path)
-           uri-path))]
-    [_ uri-path]))
+  (match* ((current-uri-prefix) uri-path)
+    [((? values prefix) (pregexp "^/.*")) (str prefix uri-path)]
+    [(_                 uri-path        ) uri-path]))
 
 (module+ test
   (let ([au "/absolute/path"]

--- a/frog/posts.rkt
+++ b/frog/posts.rkt
@@ -56,7 +56,8 @@
                                       (str dt "-" nm)))
          (read-scribble-file path
                              #:img-local-path img-dest
-                             #:img-uri-prefix (abs->rel/www img-dest))]
+                             #:img-uri-prefix (canonicalize-uri
+                                               (abs->rel/www img-dest)))]
         [(pregexp "\\.html$")
          (define same.scrbl (path-replace-suffix path ".scrbl"))
          (when (file-exists? same.scrbl)
@@ -92,7 +93,7 @@
           path
           (file-or-directory-modify-seconds path)
           dest-path
-          (post-path->link dest-path)
+          (canonicalize-uri (post-path->link dest-path))
           date
           #f ;; older
           #f ;; newer

--- a/frog/tags.rkt
+++ b/frog/tags.rkt
@@ -58,8 +58,8 @@
 
 (define (index-uri-for-tag tag)
   (match tag
-    ["all" (current-posts-index-uri)]
-    [_     (abs->rel/www (index-path-for-tag tag))]))
+    ["all" (canonicalize-uri (current-posts-index-uri))]
+    [_     (canonicalize-uri (abs->rel/www (index-path-for-tag tag)))]))
 
 (define (title-for-tag tag)
   (match tag
@@ -138,7 +138,7 @@
       (bodies->page #:title title
                     #:description title
                     #:feed feed
-                    #:uri-path (abs->rel/www file)
+                    #:uri-path (canonicalize-uri (abs->rel/www file))
                     #:keywords (cond [tag (list tag)]
                                      [else (hash-keys (all-tags))])
                     #:tag tag)
@@ -149,16 +149,17 @@
        ,(cond [(zero? page-num) `(li ([class "disabled"])
                                      (a ([href "#"]) 'larr))]
               [else `(li (a ([href ,(~> (file/page base-file (sub1 page-num))
-                                        abs->rel/www)])
+                                        abs->rel/www canonicalize-uri)])
                             'larr))])
        ,@(for/list ([n (in-range num-pages)])
            `(li (,@(cond [(= n page-num) `([class "active"])] [else '()]))
-                (a ([href ,(~> (file/page base-file n) abs->rel/www)])
+                (a ([href ,(~> (file/page base-file n) abs->rel/www 
+                               canonicalize-uri)])
                    ,(number->string (add1 n)))))
        ,(cond [(= (add1 page-num) num-pages) `(li ([class "disabled"])
                                                   (a ([href "#"]) 'rarr))]
               [else `(li (a ([href ,(~> (file/page base-file (add1 page-num))
-                                        abs->rel/www)])
+                                        abs->rel/www canonicalize-uri)])
                             'rarr))]) ))
 
 (define (file/page base-file page-num)


### PR DESCRIPTION
Hi, I've made some changes to support rerooting frog (discussed in a previous issue I think), so blogs do not need to hang under `/`.  I'm currently maintaining my own fork with these changes: it would be a good thing, for me at least, if they were merged into the real version.  They are reasonably well tested, but I didn't understand any more of frog than I needed to in order to make them (I am reasonably familiar with Racket, so the code should not be too horrid), and haven't poked around enough since to understand if they fit into the architecture.

As such you might not want to merge *these* changes, but I think something *like* them would be good: hence this request, before I forget it.  Being slightly more pragmatic, these changes do work, don't break any existing functiionality, and are reasonably easy to drive (there's just a `uri-prefix` parameter which drives everything from the config file), so they might well do in the interim.

The two important commits are

- b3bf6e3 is the support itself.
- 322929f lets you reroot the preview server -- you want this if you ever use it with rerooted blogs.

There is a slightly spurious commit (6d562a2) whose job is just to deal with Emacs backups: it's not related to the others, although it's useful (to me) and I think innocuous. It should be on another branch really but I got lazy.