### PR TITLE
Fix unicode titles in scribble pages

### DIFF
--- a/frog/non-posts.rkt
+++ b/frog/non-posts.rkt
@@ -77,14 +77,19 @@
     (cons uri-path v)))
 
 (define (make-title xs path)
+  (define (x->m el)
+    (define m (xexpr->markdown el))
+    (if (char? m)
+        (string m)
+        m))
   (or (for/or ([x (in-list xs)])
         (match x
           ;; First h1 header, if any -- Scribble style with <a> anchor
           [`(h1 (,_ ...) (a . ,_) . ,els)
-           (string-join (map xexpr->markdown els) "")]
+           (string-join (map x->m els) "")]
           ;; First h1 header, if any -- otherwise
           [`(h1 (,_ ...) . ,els)
-           (string-join (map xexpr->markdown els) "")]
+           (string-join (map x->m els) "")]
           [_ #f]))
       ;; Else name of the source file
       (~> path


### PR DESCRIPTION
For reasons that I don't understand, Scribble parses strings with non-ASCII characters into lists of strings and isolated characters. This breaks `string-join` in `make-title` in `non-posts.rkt`. This may not be the best way to fix this, but at least it works.