### PR TITLE
Add a parameter to disable showing parent tweets when embedding tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ feed-image-bugs? = true
 #
 auto-embed-tweets? = true
 
+# When embedding tweets that are replies, show the parent tweet along
+# with the reply?
+embed-tweet-parents? = true
+
 # Try to automatically link symbols in Markdown ```racket fenced code
 # blocks, to Racket documentation?
 racket-doc-link-code? = true

--- a/example/.frogrc
+++ b/example/.frogrc
@@ -67,6 +67,10 @@ feed-image-bugs? = true
 #
 auto-embed-tweets? = true
 
+# When embedding tweets that are replies, show the parent tweet along
+# with the reply?
+embed-tweet-parents? = true
+
 # Try to automatically link symbols in Markdown ```racket fenced code
 # blocks, to Racket documentation?
 racket-doc-link-code? = true

--- a/frog/enhance-body.rkt
+++ b/frog/enhance-body.rkt
@@ -128,7 +128,10 @@
          (define oembed-url
            (string->url (str "https://api.twitter.com/1/statuses/oembed.json?"
                              "url=" (uri-encode uri)
-                             "&align=center")))
+                             "&align=center"
+                             (if (current-embed-tweet-parents?)
+                                 ""
+                                 "&hide_thread=true"))))
          (define js (call/input-url oembed-url get-pure-port read-json))
          (define html ('html js))
          (cond [html (~>> (with-input-from-string html read-html-as-xexprs)

--- a/frog/frog.rkt
+++ b/frog/frog.rkt
@@ -50,6 +50,7 @@
                                [decorate-feed-uris? #t]
                                [feed-image-bugs? #f]
                                [auto-embed-tweets? #t]
+                               [embed-tweet-parents? #t]
                                [racket-doc-link-code? #t]
                                [racket-doc-link-prose? #f]
                                [posts-per-page 10]
@@ -421,6 +422,7 @@
                                [decorate-feed-uris? #t]
                                [feed-image-bugs? #f]
                                [auto-embed-tweets? #t]
+                               [embed-tweet-parents? #t]
                                [racket-doc-link-code? #t]
                                [racket-doc-link-prose? #f]
                                [posts-per-page 2] ;small, for testing

--- a/frog/params.rkt
+++ b/frog/params.rkt
@@ -26,6 +26,7 @@
 (define current-decorate-feed-uris? (make-parameter #t))
 (define current-feed-image-bugs? (make-parameter #f))
 (define current-auto-embed-tweets? (make-parameter #t))
+(define current-embed-tweet-parents? (make-parameter #t))
 (define current-racket-doc-link-code? (make-parameter #t))
 (define current-racket-doc-link-prose? (make-parameter #f))
 (define current-posts-per-page (make-parameter 10))


### PR DESCRIPTION
["No great deed was committed here"](https://brian.mastenbrook.net/blog/2015/we-considered-ourselves-to-be-a-humorous-people.html)