### PR TITLE
Fix bad syntax highlighting

### DIFF
--- a/frog/enhance-body.rkt
+++ b/frog/enhance-body.rkt
@@ -13,8 +13,7 @@
          "html.rkt"
          "params.rkt"
          "pygments.rkt"
-         "xexpr-map.rkt"
-         "xexpr2text.rkt")
+         "xexpr-map.rkt")
 
 (provide enhance-body)
 
@@ -29,12 +28,12 @@
 (define (syntax-highlight xs)
   (for/list ([x xs])
     (match x
-      [(or `(pre ([class ,brush]) (code () ,texts ...))
-           `(pre ([class ,brush]) ,texts ...))
+      [(or `(pre ([class ,brush]) (code () ,(? string? texts) ...))
+           `(pre ([class ,brush]) ,(? string? texts) ...))
        (match brush
          [(pregexp "\\s*brush:\\s*(.+?)\\s*$" (list _ lang))
           `(div ([class ,(str "brush: " lang)])
-                ,@(pygmentize (apply string-append (map xexpr->markdown texts)) lang))]
+                ,@(pygmentize (apply string-append texts) lang))]
          [_ `(pre ,@texts)])]
       [x x])))
 

--- a/frog/enhance-body.rkt
+++ b/frog/enhance-body.rkt
@@ -13,7 +13,8 @@
          "html.rkt"
          "params.rkt"
          "pygments.rkt"
-         "xexpr-map.rkt")
+         "xexpr-map.rkt"
+         "xexpr2text.rkt")
 
 (provide enhance-body)
 
@@ -28,12 +29,12 @@
 (define (syntax-highlight xs)
   (for/list ([x xs])
     (match x
-      [(or `(pre ([class ,brush]) (code () ,(? string? texts) ...))
-           `(pre ([class ,brush]) ,(? string? texts) ...))
+      [(or `(pre ([class ,brush]) (code () ,texts ...))
+           `(pre ([class ,brush]) ,texts ...))
        (match brush
          [(pregexp "\\s*brush:\\s*(.+?)\\s*$" (list _ lang))
           `(div ([class ,(str "brush: " lang)])
-                ,@(pygmentize (apply string-append texts) lang))]
+                ,@(pygmentize (apply string-append (map xexpr->markdown texts)) lang))]
          [_ `(pre ,@texts)])]
       [x x])))
 

--- a/frog/scribble.rkt
+++ b/frog/scribble.rkt
@@ -21,4 +21,4 @@
   (para #:style (style "brush:"
                        (list (attributes `([class . ,lang]))
                              (alt-tag "pre")))
-        (literal xs)))
+        (apply literal xs)))

--- a/frog/scribble.rkt
+++ b/frog/scribble.rkt
@@ -2,7 +2,8 @@
 
 (require (only-in scribble/core style)
          (only-in scribble/manual para)
-         (only-in scribble/html-properties attributes alt-tag))
+         (only-in scribble/html-properties attributes alt-tag)
+         (only-in scribble/base literal))
 
 (provide pygment-code)
 
@@ -20,4 +21,4 @@
   (para #:style (style "brush:"
                        (list (attributes `([class . ,lang]))
                              (alt-tag "pre")))
-        xs))
+        (literal xs)))


### PR DESCRIPTION
Suppose the text passed to `pygment-code` is following:

```
-  RPROMPT='${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}'
+  RPROMPT='[%D{%L:%M:%S %p}]'
+  #RPROMPT='${editor_info[overwrite]}%(?:: %F{1}⏎%f)${VIM:+" %B%F{6}V%f%b"}'
```

Obviously, we should be able to highlight it. However, `texts` will not be all string. For example, `⏎` will result in a code (number) 9166. `'` will result in `'rsquo`. Therefore, the `match` fails, and it falls back to the `[x x]` case which is definitely not what we want.

If we have something in the following form: `<pre class="brush: ...">`, it's pretty safe to assume that things inside is highlightable (if not, I feel that the original code will break too anyway!), so it's safe to apply `xexpr->markdown`.

Potentially fix #165 (I'm not exactly sure if this is the issue that @LeifAnderson experienced or not), but this definitely fixes a bug that I am experiencing