### PR TITLE
Explicit use isPermalink="false" in Frog RSS feeds

### DIFF
--- a/frog/feeds.rkt
+++ b/frog/feeds.rkt
@@ -119,7 +119,7 @@
     ()
     (title ,title)
     (link ,item-uri)
-    (guid () ,(str "urn:"
+    (guid ([isPermaLink "false"]) ,(str "urn:"
                    (our-encode (current-scheme/host))
                    ":"
                    (our-encode uri-path)))


### PR DESCRIPTION
Thunderbird as a RSS client does not correctly render Frog-produced
blogs: the web link shown to the user is the guid flag, which is not
a URL (it is a mangled URL) and doesn't go anywhere when you click on
it.

The RSS currently generated looks like:

    <guid>urn:http-prl-ccs-neu-edu:-blog-2017-02-21-bullets-are-good-for-your-coq-proofs</guid>

According to the RSS specification, this is incorrect: there is
a `isPermaLink` attribute that indicate whether or not the guid can be
interpreted as a URL, but its default value is `"true"`. So if we
include a <guid> element in the output, we *must* specify
`isPermaLink="false"`. See the specification:

  https://validator.w3.org/feed/docs/rss2.html#ltguidgtSubelementOfLtitemgt