### PR TITLE
example/custom.css: include a useful snippet to avoid image overflow

### DIFF
--- a/example/css/custom.css
+++ b/example/css/custom.css
@@ -11,3 +11,16 @@ pre {
     white-space: pre;
     width: inherit;
 }
+
+article img {
+  /* Make sure that images within blog articles never take more width
+     than the article width; `height: auto` ensures the height is also
+     resized proportionally.
+
+     This is useful given that Markdown itself gives you little
+     control over image resizing, and in particular no way to achieve
+     this "best fit" behavior.
+ */
+  max-width: 100%;
+  height: auto;
+}


### PR DESCRIPTION
We needed this on the PRL blog, and I don't see any situation where you would not want this by default, so I think that upstreaming it would be useful.