### PR TITLE
Nicer error message when date is malformed

### DIFF
--- a/frog/private/bodies-page.rkt
+++ b/frog/private/bodies-page.rkt
@@ -159,6 +159,7 @@
                [xs xs]))
   (string-join (map xexpr->string xs) ""))
 
+;; Raises a contract error on invalid date
 (define (date->date-struct YYYY-MM-DD-string)
   (match YYYY-MM-DD-string
     [(pregexp "(\\d{4})-(\\d{2})-(\\d{2})" (list _ y m d))

--- a/frog/private/posts.rkt
+++ b/frog/private/posts.rkt
@@ -129,8 +129,15 @@
             #:when (member k '("Title" "Date" "Tags" "Authors"))
             (hash-set h (string-trim k) (string-trim v))]
            [s (warn s) h])))
+     (define d
+       (with-handlers ([exn:fail:contract?
+                        (λ _
+                          (err "`Date` is malformed, must be yyyy-mm-ddThr:mn:sc format"))])
+         (define d0 (hash-ref h "Date" (λ _ (err "missing `Date`"))))
+         (date->date-struct d0)
+         d0))
      (list (hash-ref h "Title" (λ _ (err "missing `Title`")))
-           (hash-ref h "Date" (λ _ (err "missing `Date`")))
+           d
            (append (~>> (hash-ref h "Tags" "")
                         tag-string->tags)
                    (~>> (hash-ref h "Authors" "")


### PR DESCRIPTION
Fixes #199 .
Basically the fix you suggested, but using `exn:fail:contract?` instead of `exn:fail?` to avoid potentially hiding other bugs.

Tested it manually by changing one of the examples to have a bad date.