### PR TITLE
(wip) Editing older/newer-links function for Bootstrap 4

### DIFF
--- a/example/_src/post-template.html
+++ b/example/_src/post-template.html
@@ -9,6 +9,33 @@
     @twitter-share-button[full-uri]
     @google-plus-share-button[full-uri]
     @disqus-comments["shortname"]
-    @older/newer-links[older-uri older-title newer-uri newer-title]
+    @;(older/newer-links[older-uri older-title newer-uri newer-title])
+
+    @(define (page-navigation prev-uri prev-title new-uri new-title)
+      @list{
+        <div class="row justify-content-center">
+          <nav aria-label="Page Navigation">
+	    <ul class="pagination">
+	      @(when prev-uri
+	        @list{
+	          <li class="page-item">
+	            <a class="page-link" href="@|prev-uri|" aria-label="Previous">
+		      <span aria-hidden="true">&larr; @|prev-title|</span>
+	            </a>
+	          </li>
+	        })
+	      @(when new-uri
+	        @list{
+	          <li class="page-item">
+	            <a class="page-link" href="@|new-uri|" aria-label="Next">
+		      <span aria-hidden="true">@|new-title| &rarr;</span>
+	            </a>
+	          </li>
+	        })
+	    </ul>
+          </nav>
+	</div>})
+
+    @page-navigation[older-uri older-title newer-uri newer-title]
   </footer>
 </article>


### PR DESCRIPTION
So after doing the Bootstrap 4 transition, I realized that the paging between newer and older posts was not properly adjusted for Boostrap 4 (my bad). Here I adjust the function `older/newer-links` underneath `widgets.rkt`. I implemented the same code on my website, so I figured I'd PR it to Frog as well.

I'm not certain if I'm doing something wrong or not, but I couldn't quite get it to work under a blind test, ie: on a fresh project, generating pages would not use this change for some reason (not certain if it's because it's using my local Frog install or not). Is there anything I'm missing?