### PR TITLE
suppress warning for empty Tags:

### DIFF
--- a/frog/private/posts.rkt
+++ b/frog/private/posts.rkt
@@ -125,7 +125,7 @@
        (for/fold ([h (hash)])
                  ([s (string-split plain-text "\n")])
          (match s
-           [(pregexp "^(.+?):(.+?)$" (list _ k v))
+           [(pregexp "^(.+?):(.*?)$" (list _ k v))
             #:when (member k '("Title" "Date" "Tags" "Authors"))
             (hash-set h (string-trim k) (string-trim v))]
            [s (warn s) h])))
@@ -179,7 +179,13 @@
     (check-equal? (meta-data `((pre () "Title: title\nDate: date\nTags:\n")) p)
                   (list "title" "date" '() '()))
     (check-equal? (meta-data `((pre () "Title: title\nDate: date\n")) p)
-                  (list "title" "date" '() '()))))
+                  (list "title" "date" '() '())))
+  (test-case "https://github.com/greghendershott/frog/issues/211"
+    (check-equal? (meta-data `((pre () (code () "Title: title\nDate: date\nTags:\n"))) p)
+                  (list "title" "date" '() '()))
+    (check-equal? (with-output-to-string
+                    (λ () (meta-data `((pre () (code () "Title: title\nDate: date\nTags:\n"))) p)))
+                  "")))
 
 (define (tag-string->tags s)
   (match (regexp-split #px"," (string-trim s))


### PR DESCRIPTION
This PR widens the regexp used to match metadata fields to allow an empty string to the right of the colon (that is, + turns into *). This suppresses the warning that's currently associated with using "Tags: ". Reading the further-down code suggests that the later hash mapping from tags to '("") is treated the same as not having a mapping at all.

My only question about this change is what exactly it means to have a title or date which is whitespace-only. IIUC the current code prevents "Title:" but allows "Title:    ". Following this PR, both appear to be allowed. I think that probably these should *both* be disallowed. So maybe there's another piece of code to add here, but I didn't want to do that without consulting.