### PR TITLE
Scribble sources: Point user-scope xrefs to local-redirect. Closes #229

### DIFF
--- a/frog/private/read-scribble.rkt
+++ b/frog/private/read-scribble.rkt
@@ -30,6 +30,7 @@
                           "--html"
                           "--dest" dir
                           "--dest-name" "frog.html"
+                          "--redirect" "https://docs.racket-lang.org/local-redirect/"
                           "--redirect-main" "https://docs.racket-lang.org"
                           "++xref-in" "setup/xref" "load-collections-xref"
                           (path->string path))])


### PR DESCRIPTION
By default, scribble resolves cross-refereces into packages installed locally,
in user-scope, to local filesystem paths. This is not so useful for rendering
a blog. Instead, all links should point into the official Racket docs server.

This patches the default behavior to make all cross-references into non-main
packages point to `https://docs.racket-lang.org/local-redirect/`.

The trailing forward slash is important, otherwise the browser stays on a
generic "Redirections" page indicating the redirect failed.

See https://docs.racket-lang.org/pkg/implementation.html section 12.3 for an
overview of the local-redirect mechanism.