### PR TITLE
Improve --watch

### DIFF
--- a/THANKS.md
+++ b/THANKS.md
@@ -12,7 +12,7 @@ Thanks to the following people for contributing pull requests!
 - [Tim Bradshaw](https://github.com/tfeb)
 - [Konrad Hinsen](https://github.com/khinsen)
 - [Leif Andersen](https://github.com/LeifAndersen)
-- [sorawee](https://github.com/sorawee)
+- [Sorawee Porncharoenwase](https://github.com/sorawee)
 - [Jordan Johnson](https://github.com/RenaissanceBug)
 - [Gabriel Scherer](https://github.com/gasche)
 - [Brian Mastenbrook](https://github.com/bmastenbrook)

--- a/frog/config/private/load.rkt
+++ b/frog/config/private/load.rkt
@@ -20,7 +20,7 @@
 
         (define (load top)
           (define frog.rkt (build-path top "frog.rkt"))
-          (let ([fn (with-handlers ([exn:fail? cannot-find-frog.rkt])
+          (let ([fn (with-handlers ([exn:fail:filesystem? cannot-find-frog.rkt])
                       (dynamic-require frog.rkt 'id))])
             (when fn (set! id fn))) ...)
         (provide load))))

--- a/frog/frog.scrbl
+++ b/frog/frog.scrbl
@@ -924,6 +924,9 @@ This may be an absolute or relative path. If relative, it's relative
 to the project top directory, i.e. to where @secref["config"] is
 located.}
 
+@defparam[current-watch-rate rate exact-positive-integer? #:value 5]{
+The number of seconds to wait between each change watching.}
+
 @defparam[current-rebuild?
           rebuild?
           (path? (or/c 'create 'delete 'modify) . -> . boolean?)]{
@@ -934,8 +937,9 @@ on every file change (create, delete, modify) in the project. If @racket[rebuild
 returns @racket[#f], then Frog will not rebuild the project
 (for this particular change). Otherwise, Frog will rebuild the project.
 
-By default, any file change will trigger a rebuild, except the case where
-the changed file has an extension either @tt{html}, @tt{txt}, or @tt{xml},
+By default, @racket[rebuild?] will return @racket[#t] and also make a beep,
+except the case where the changed file has an extension either
+@tt{html}, @tt{txt}, or @tt{xml} which will return @racket[#f],
 as it is likely that the file will be an output.}
 
 @section[#:tag "body-enhancers"]{Body enhancers}

--- a/frog/frog.scrbl
+++ b/frog/frog.scrbl
@@ -929,9 +929,9 @@ located.}
           (path-string? (or/c 'create 'delete 'modify) . -> . boolean?)]{
 The procedure to test if a file change during a watch needs a rebuild.
 
-If Frog is run with the @tt{-w} or @tt{--watch} flag, @racket{rebuild?} will be invoked
-on every file change (create, delete, modify) in the project. If @racket{rebuild?}
-returns @racket{#f}, then Frog will not rebuild the project
+If Frog is run with the @tt{-w} or @tt{--watch} flag, @racket[rebuild?] will be invoked
+on every file change (create, delete, modify) in the project. If @racket[rebuild?]
+returns @racket[#f], then Frog will not rebuild the project
 (for this particular change). Otherwise, Frog will rebuild the project.
 
 By default, any file change will trigger a rebuild, except the case where

--- a/frog/frog.scrbl
+++ b/frog/frog.scrbl
@@ -924,6 +924,19 @@ This may be an absolute or relative path. If relative, it's relative
 to the project top directory, i.e. to where @secref["config"] is
 located.}
 
+@defparam[current-rebuild?
+          rebuild?
+          (path-string? (or/c 'create 'delete 'modify) . -> . boolean?)]{
+The procedure to test if a file change during a watch needs a rebuild.
+
+If Frog is run with the @tt{-w} or @tt{--watch} flag, @racket{rebuild?} will be invoked
+on every file change (create, delete, modify) in the project. If @racket{rebuild?}
+returns @racket{#f}, then Frog will not rebuild the project
+(for this particular change). Otherwise, Frog will rebuild the project.
+
+By default, any file change will trigger a rebuild, except the case where
+the changed file has an extension either @tt{html}, @tt{txt}, or @tt{xml},
+as it is likely that the file will be an output.}
 
 @section[#:tag "body-enhancers"]{Body enhancers}
 

--- a/frog/frog.scrbl
+++ b/frog/frog.scrbl
@@ -926,7 +926,7 @@ located.}
 
 @defparam[current-rebuild?
           rebuild?
-          (path-string? (or/c 'create 'delete 'modify) . -> . boolean?)]{
+          (path? (or/c 'create 'delete 'modify) . -> . boolean?)]{
 The procedure to test if a file change during a watch needs a rebuild.
 
 If Frog is run with the @tt{-w} or @tt{--watch} flag, @racket[rebuild?] will be invoked

--- a/frog/private/main.rkt
+++ b/frog/private/main.rkt
@@ -391,8 +391,7 @@
 (define (watch-callback path change-type)
   (when ((current-rebuild?) path change-type)
     (with-handlers ([exn:fail? (compose1 displayln exn->string)])
-      (build))
-    (display #"\007"))) ; beep (hopefully)
+      (build))))
 
 (define (serve #:launch-browser? launch-browser?
                #:watch? watch?
@@ -406,7 +405,7 @@
                   (watch-directory (build-path watch-path)
                                    '(file)
                                    watch-callback
-                                   #:rate 5)]
+                                   #:rate (current-watch-rate))]
           [else (thread (thunk (sync never-evt)))]))
   (when launch-browser?
     (ensure-external-browser-preference))

--- a/frog/private/main.rkt
+++ b/frog/private/main.rkt
@@ -11,7 +11,6 @@
          racket/runtime-path
          racket/set
          racket/vector
-         racket/exn
          rackjure/threading
          web-server/dispatchers/dispatch
          web-server/servlet-env

--- a/frog/private/main.rkt
+++ b/frog/private/main.rkt
@@ -115,10 +115,11 @@
      #:once-each
      [("-w" "--watch")
       (""
-       "(Experimental: Only rebuilds some files.)"
-       "Supply this flag before -s/--serve or -p/--preview."
-       "Watch for changed files, and generate again."
-       "(You'll need to refresh the browser yourself.)")
+       "(Experimental!) Supply this flag before -s/--serve or -p/--preview."
+       "Watch for changed files, and regenerate the project."
+       "(You'll need to refresh the browser yourself.)"
+       "Customize which files should trigger the regeneration"
+       "by using current-rebuild?")
       (set! watch? #t)]
      [("--port") number
       (""
@@ -387,13 +388,10 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(define (watch-callback path what)
-  (match (path->string path)
-    ;; Output file
-    [(pregexp "\\.(?:html|xml|txt)") (void)]
-    ;; Source file
-    [_ (build)
-       (displayln #"\007")])) ;beep (hopefully)
+(define (watch-callback path change-type)
+  (when ((current-rebuild?) path change-type)
+    (build)
+    (displayln #"\007"))) ; beep (hopefully)
 
 (define (serve #:launch-browser? launch-browser?
                #:watch? watch?

--- a/frog/private/main.rkt
+++ b/frog/private/main.rkt
@@ -29,7 +29,7 @@
          "serialize-posts.rkt"
          "stale.rkt"
          "tags.rkt"
-         "util.rkt"
+         (except-in "util.rkt" path-get-extension)
          "verbosity.rkt"
          "watch-dir.rkt")
 

--- a/frog/private/main.rkt
+++ b/frog/private/main.rkt
@@ -11,6 +11,7 @@
          racket/runtime-path
          racket/set
          racket/vector
+         racket/exn
          rackjure/threading
          web-server/dispatchers/dispatch
          web-server/servlet-env
@@ -390,8 +391,9 @@
 
 (define (watch-callback path change-type)
   (when ((current-rebuild?) path change-type)
-    (build)
-    (displayln #"\007"))) ; beep (hopefully)
+    (with-handlers ([exn:fail? (compose1 displayln exn->string)])
+      (build))
+    (display #"\007"))) ; beep (hopefully)
 
 (define (serve #:launch-browser? launch-browser?
                #:watch? watch?

--- a/frog/private/non-posts.rkt
+++ b/frog/private/non-posts.rkt
@@ -13,7 +13,7 @@
          "read-scribble.rkt"
          "stale.rkt"
          "template.rkt"
-         "util.rkt"
+         (except-in "util.rkt" path-get-extension)
          "verbosity.rkt"
          "xexpr2text.rkt")
 

--- a/frog/private/params.rkt
+++ b/frog/private/params.rkt
@@ -32,7 +32,12 @@
 (define current-posts-index-uri (make-parameter "/index.html"))
 (define current-source-dir (make-parameter "_src"))
 (define current-output-dir (make-parameter "."))
+(define current-watch-rate (make-parameter 5))
 (define current-rebuild?
   (make-parameter
    (λ (path change-type)
-     (not (member (path-get-extension path) '(#".html" #".txt" #".xml"))))))
+     (cond
+       [(not (member (path-get-extension path) '(#".html" #".txt" #".xml")))
+        (display #"\007") ; beep (hopefully)
+        #t]
+       [else #f]))))

--- a/frog/private/params.rkt
+++ b/frog/private/params.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require racket/match racket/path)
+(require racket/match
+         "./util.rkt")
 
 (provide (all-defined-out))
 

--- a/frog/private/params.rkt
+++ b/frog/private/params.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require racket/match)
+(require racket/match racket/path)
 
 (provide (all-defined-out))
 
@@ -31,3 +31,7 @@
 (define current-posts-index-uri (make-parameter "/index.html"))
 (define current-source-dir (make-parameter "_src"))
 (define current-output-dir (make-parameter "."))
+(define current-rebuild?
+  (make-parameter
+   (λ (path change-type)
+     (not (member (path-get-extension path) '(#".html" #".txt" #".xml"))))))

--- a/frog/private/util.rkt
+++ b/frog/private/util.rkt
@@ -16,7 +16,8 @@
          delete-files*
          in-slice
          split-common-prefix
-         path-get-extension)
+         path-get-extension
+         exn->string)
 
 ;; Less typing, and also returns its value so good for sticking in
 ;; threading macros for debugging.
@@ -104,6 +105,18 @@
          [name (and name (path->bytes name))])
     (cond [(and name (regexp-match #rx#"(?<=.)([.][^.]+)$" name)) => cadr]
           [else #f])))
+
+
+;; NOTE: these functions are copied from
+;; https://github.com/racket/racket/blob/master/racket/collects/racket/exn.rkt
+;; once we decide to drop the support of versions below 6.3, delete them
+;; and switch to use exn->string from racket/exn instead
+(define (exn->string exn)
+  (if (exn? exn)
+      (parameterize ([current-error-port (open-output-string)])
+        ((error-display-handler) (exn-message exn) exn)
+        (get-output-string (current-error-port)))
+      (format "~s\n" exn)))
 
 (module+ test
   (require rackunit)


### PR DESCRIPTION
1. There are several reasons why `frog.rkt` might not be loadable.
   We only want to show a nice warning that users should initialize the project
   when the exception is filesystem-related. Other errors like syntax errors /
   unbound ids should not be caught.

2. Improve `--watch` flag by allowing users to customize whether or not
   they want to trigger a rebuild or not. The default behavior is
   backward-compatible with the current behavior.

3. Don't print `\n` when beeping in `--watch`.

4. If an error happens during a build with `--watch`, prevent Frog from catastrophically fail. Note that this is especially common when editing a Scribble post file.