### PR TITLE
Sync with https://help.disqus.com/installation/universal-embed-code

### DIFF
--- a/frog/widgets.rkt
+++ b/frog/widgets.rkt
@@ -124,9 +124,14 @@
               dsq.type = 'text/javascript';
               dsq.async = true;
               dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+              dsq.setAttribute('data-timestamp', +new Date());
               (document.head || document.body).appendChild(dsq);
           })();
         </script>
+        <noscript>
+          Please enable JavaScript to view the
+          <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a>
+        </noscript>
         })
 
 (define/doc (livefyre [site-id string?] list?)


### PR DESCRIPTION
In particular, add <noscript> so that browsers without JavaScript support
will get a warning