### PR TITLE
use python.exe as default python executable name in windows

### DIFF
--- a/example/frog.rkt
+++ b/example/frog.rkt
@@ -1,3 +1,4 @@
+
 #lang frog/config
 
 ;; Called early when Frog launches. Use this to set parameters defined
@@ -13,7 +14,9 @@
   (-> (listof xexpr/c) (listof xexpr/c))
   ;; Here we pass the xexprs through a series of functions.
   (~> xs
-      (syntax-highlight #:python-executable "python"
+      (syntax-highlight #:python-executable (if (eq? (system-type) 'windows)
+                                                "python.exe"
+                                                "python")
                         #:line-numbers? #t
                         #:css-class "source")
       (auto-embed-tweets #:parents? #t)

--- a/frog/enhance-body.rkt
+++ b/frog/enhance-body.rkt
@@ -22,7 +22,9 @@
 
 (define/doc (syntax-highlight
              [x-expressions (listof xexpr/c)]
-             [#:python-executable python-executable path-string? "python"]
+             [#:python-executable python-executable path-string? (if (eq? (system-type) 'windows)
+                                                                     "python.exe"
+                                                                     "python")]
              [#:line-numbers? line-numbers? boolean? #t]
              [#:css-class css-class string? "source"]
              (listof xexpr/c))


### PR DESCRIPTION
Hi, 

This is for the [issue 209](https://github.com/greghendershott/frog/issues/209)