### PR TITLE
math-jax widget: make it possible to suppress configuration

### DIFF
--- a/frog/widgets.rkt
+++ b/frog/widgets.rkt
@@ -326,7 +326,8 @@
 
 (define/doc (math-jax [#:src src string?
                        "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js"]
-                      [#:config config string? "TeX-AMS-MML_HTMLorMML"]
+                      [#:config config (or/c #f string?)
+                       "TeX-AMS-MML_HTMLorMML"]
                       list?)
   @{@itemlist[#:style 'ordered
               @item{Use this in the @tt{<head>} of your @secref["page-template"].}
@@ -336,12 +337,20 @@
                     markdown @litchar{\} already has a meaning.}
               @item{You can specify the source URL and configuration options
                     with the @tt{src} & @tt{config} arguments: they default to
-                    something reasonable.}]}
-  @list{
-        <script type="text/javascript" async
-                src="@|src|?config=@|config|">
-        </script>
-       })
+                    something reasonable.  If the @tt{config} argument is
+                    given as @tt{#f} then the configuration is omitted, which
+                    which is right for MathJax 3.  In this case you either
+                    will need to use one of the default setups or hand-craft
+                    your own configuration.}]}
+  @(if (not config)
+       @list{
+             <script type="text/javascript" async
+                     src="@|src|">
+             </script>}
+       @list{
+             <script type="text/javascript" async
+                     src="@|src|?config=@|config|">
+             </script>}))
 
  (define/doc (piwik [site string?]
                     [domain string?]


### PR DESCRIPTION
This makes a small, compatible, change to the `math-jax` widget which helps support for MathJax 3.  The change is to allow the `#:config` option to be  `#f` (previously it had to be a string).  Doing this will cause no configuration part to be added to the MathJax URL, which is needed for MathJax 3, which does configuration a different way.

This can't make any difference to any existing uses of the widget, since previously this option had to be a string, so `#f` would have been illegal.

This is the first of two changes needed for #252, the other one being a change to   [markdown](https://github.com/greghendershott/markdown), which I need to check a bit more.  As this is so simple and compatible I figured I should get this out of the way first so I can stop needing to rebase my branch.

I'm willing to handle any support problems which arise as a result of this change.
