### PR TITLE
Default python executable should be python3

### DIFF
--- a/example/frog.rkt
+++ b/example/frog.rkt
@@ -15,8 +15,8 @@
   ;; Here we pass the xexprs through a series of functions.
   (~> xs
       (syntax-highlight #:python-executable (if (eq? (system-type) 'windows)
-                                                "python.exe"
-                                                "python")
+                                                "python3.exe"
+                                                "python3")
                         #:line-numbers? #t
                         #:css-class "source")
       (auto-embed-tweets #:parents? #t)


### PR DESCRIPTION
On Mac (still) the default python is python2, but it's python3 that you almost
certainly want. Make this the default.