### PR TITLE
Work around reprovide-lang upstream issue

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -6,7 +6,7 @@
                "html-lib"
                ["markdown" #:version "0.25"]
                "racket-index"
-               "reprovide-lang"
+               "reprovide-lang-lib"
                "scribble-lib"
                "scribble-text-lib"
                "srfi-lite-lib"


### PR DESCRIPTION
Ran into this when building a website with frog while using the `racket/racket:8.3-full` docker image.  The work around is to only install the `reprovide-lang-lib`.  Hopefully upstream comes up with a fix but this will address the issue with frog in particular.

https://github.com/AlexKnauth/reprovide-lang/issues/14