### PR TITLE
update metadata extracton for newer Scribble

### DIFF
--- a/frog/private/posts.rkt
+++ b/frog/private/posts.rkt
@@ -120,7 +120,8 @@
     [`(,(or `(pre () (code () . ,metas)) ;Markdown
             `(pre () . ,metas)           ;Markdown
             `(pre . ,metas)              ;Markdown
-            `(p () . ,metas))            ;Scribble
+            `(p () . ,metas)             ;Scribble
+            `(section ,_ (p () . ,metas) . ,_)) ;Scribble
        . ,more)
      ;; We don't want HTML entities like &ndash;
      (define plain-text (string-join (map xexpr->markdown metas) ""))


### PR DESCRIPTION
Never versions of Scribble put document content in a `section` element.

I'm not sure that adjusting `meta-data` is the right approach. It could be that `adjust-scribble-html` in `read-scribble.rkt` is the right thing to change, instead.